### PR TITLE
update memcached-session-manager version

### DIFF
--- a/StandaloneTomcatMemcachedGrailsPlugin.groovy
+++ b/StandaloneTomcatMemcachedGrailsPlugin.groovy
@@ -7,7 +7,7 @@ class StandaloneTomcatMemcachedGrailsPlugin {
 
 	private final Logger log = LoggerFactory.getLogger('grails.plugin.standalone.StandaloneTomcatMemcachedGrailsPlugin')
 
-	String version = '0.1'
+	String version = '0.2'
 	String grailsVersion = '2.0 > *'
 	List pluginExcludes = [
 		'docs/**',

--- a/application.properties
+++ b/application.properties
@@ -1,1 +1,4 @@
-app.grails.version=2.0.4
+#Grails Metadata file
+#Thu Mar 13 11:14:27 PDT 2014
+app.grails.version=2.3.6
+app.servlet.version=2.5

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -15,14 +15,14 @@ grails.project.dependency.resolution = {
 
 	dependencies {
 		
-		compile 'de.javakaffee.msm:memcached-session-manager:1.6.4', {
+		compile 'de.javakaffee.msm:memcached-session-manager:1.8.1', {
 			excludes 'CouchbaseMock', 'annotations', 'catalina', 'catalina-ha', 'couchbase-client', 'coyote',
 			         'hibernate-annotations', 'hibernate-core', 'hsqldb', 'httpclient', 'javassist',
 			         'jettison', 'jmemcached-core', 'jsr305', 'mockito-core', 'netty', 'servlet-api',
 			         'slf4j-simple', 'spymemcached', 'testng'
 		}
 
-		compile 'de.javakaffee.msm:memcached-session-manager-tc7:1.6.4', {
+		compile 'de.javakaffee.msm:memcached-session-manager-tc7:1.8.1', {
 			excludes 'CouchbaseMock', 'annotations', 'hibernate-annotations', 'hibernate-core', 'hsqldb',
 			         'httpclient', 'javassist', 'jettison', 'jmemcached-core', 'jsr305', 'memcached-session-manager',
 			         'mockito-core', 'netty', 'slf4j-simple', 'testng', 'tomcat-catalina', 'tomcat-catalina-ha',
@@ -54,6 +54,9 @@ grails.project.dependency.resolution = {
 			         'jboss-marshalling', 'jboss-marshalling-river', 'jboss-marshalling-serial', 'junit', 'log4j',
 			         'org.osgi.compendium', 'org.osgi.core', 'protobuf-java', 'servlet-api', 'slf4j-api', 'slf4j-simple'
 		}
+
+    build 'org.apache.geronimo.ext.tomcat:catalina:7.0.39.2'
+
 	}
 
 	plugins {

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -4,3 +4,4 @@ log4j = {
 	      'org.hibernate',
 	      'net.sf.ehcache.hibernate'
 }
+


### PR DESCRIPTION
- update memcached-session-manager from 1.6.4 to 1.8.1. About a year between these, many updates especially around retry logic.
- update our version number.
- upgrade our grails version.
- add a build dependency on tomcat so module compiles.
